### PR TITLE
Changes to PR for New Leaderboard JSON Response

### DIFF
--- a/app/src/app.py
+++ b/app/src/app.py
@@ -19,6 +19,7 @@ def create_app(test_config=None):
 
     # Configure and initialize database
     app.config['SQLALCHEMY_DATABASE_URI'] = 'sqlite:///site.db'
+    app.config['PER_PAGE'] = 10
     app.secret_key = os.getenv('SECRET_KEY')
     app.register_blueprint(auth_blueprint)
     app.register_blueprint(main_blueprint)
@@ -47,40 +48,4 @@ def create_app(test_config=None):
     with app.app_context():
         db.create_all()
         
-    # Pagination configuration
-    PER_PAGE = 10
-
-    def sort_leaderboard():
-        # Implement your sorting logic here
-        # For example, assuming User model has a 'score' field
-        return User.query.order_by(User.score.desc()).all()
-
-    @app.route('/leaderboard', methods=['GET'])
-    def leaderboard():
-        page = request.args.get('page', 1, type=int)
-        per_page = request.args.get('per_page', PER_PAGE, type=int)
-
-        leaderboard_data = sort_leaderboard()
-        total_users = len(leaderboard_data)
-
-        start_index = (page - 1) * per_page
-        end_index = start_index + per_page
-        paginated_data = leaderboard_data[start_index:end_index]
-
-        # Construct JSON response
-        response = {
-            'leaderboard_data': [
-                {
-                    'rank': (page - 1) * per_page + i + 1,
-                    'username': user.username,
-                    'points': user.points
-                } for i, user in enumerate(leaderboard_data)
-            ],
-            'page': page,
-            'per_page': per_page,
-            'total_users': total_users
-        }
-
-        return jsonify(response)
-
         # return app


### PR DESCRIPTION
**Changes:**
- Added the per_page amount to the app configuration 
- Removed the sort_leaderboard function because I wasn't too sure of the best place to put it since it needs to be accessed from the routes.py and main.py files. I moved the query inside the JSON response instead because I added the pagination feature to the query and we need the leaderboard page and per_page values. I think it would make more sense to have those values alongside the leaderboard query in the actual routes so the code is easier to understand.
- https://blog.miguelgrinberg.com/post/the-flask-mega-tutorial-part-ix-pagination (Link that goes over the Flask paginate feature)

- There's a similar JSON response to the one you made in routes.py (where all the JSON responses are being stored), so I deleted the one you had in app.py, but modified the existing one to include some of the important features from your JSON response
- Modified the dashboard route so that the leaderboard data is sent in and the top 5 users can be retrieved with your edit to the dashboard.html file
- Modified the leaderboard route (the one that initially renders the leaderboard page) so that we make use of the pagination feature to ensure that we don't query every user in the leaderboard (inefficient) and we can make use of the JSON response that can dynamically retrieve the next set of users as we go through the leaderboard pages

**Things to change moving forward/notes to include in your PR:**
- We added the JSON response that can retrieve the next set of users as we go through the leaderboard pages, but the actual HTML isn't set up yet to handle going to the next page/previous page. We need to add that feature and also add a script to the frontend to actually make use of the JSON response created and update the current page number (need this because the JSON response depends on the page argument that should be included in the URL to determine which set of users to query next). Need to set up AJAX calls to use the JSON response when a user interacts with the pagination controls.
- We can maybe make use of the calculateRanking file in the utils directory in the future, as it might be more efficient than accessing the database directly for leaderboard info
- Added some attributes to the initial leaderboard route such as current_page, has_next and next_page, that we can incorporate into the frontend once we set up the pagination controls (adding attributes for total pages/users in leaderboard later might also be useful?)


You can make any changes to this PR you think might be useful or let me know if you think there's anything I missed. If it looks good, you can update your PR to the main repo with these changes and we should be good to go.